### PR TITLE
API Changes for Incidence Rates

### DIFF
--- a/R/CharacterzationQueries.R
+++ b/R/CharacterzationQueries.R
@@ -12,6 +12,7 @@
 #' @template cgTablePrefix
 #' @template databaseTable
 #' @template targetIds
+#' @template outcomeIds
 #' @template outcomeCohortIds
 #' @family Characterization
 #' @return
@@ -63,7 +64,8 @@ getIncidenceRates <- function(
     cgTablePrefix = 'cg_',
     databaseTable = 'database_meta_data',
     targetIds = NULL,
-    outcomeCohortIds = NULL
+    outcomeIds = NULL, # This should be removed in next major release in favor of 'outcomeCohortIds'.
+    outcomeCohortIds = outcomeIds
 ){
   
   sql <- 'select 

--- a/inst/templates/presentation/cohort_incidence_template.qmd
+++ b/inst/templates/presentation/cohort_incidence_template.qmd
@@ -8,14 +8,14 @@
 cat("\n::: {style='font-size: 50%;'}\n\n")
 cat('\n\n:::: {.panel-tabset .nav-pills}\n')
 for(outcomeInd in 1:nrow(outcomes)){
-  outcomeId <- outcomes$cohortDefinitionId[outcomeInd]
+  outcomeCohortId <- outcomes$cohortDefinitionId[outcomeInd]
   outcomeName <- outcomes$cohortFriendlyName[outcomeInd]
   
 incidence <- OhdsiReportGenerator::getIncidenceRates(
     connectionHandler = connectionHandler,
     schema = resultsSchema,
     targetIds = ciIds,
-    outcomeIds = outcomeId
+    outcomeCohortIds = outcomeCohortId
 )
 
 if(nrow(incidence) > 0 ){

--- a/man-roxygen/outcomeCohortIds.R
+++ b/man-roxygen/outcomeCohortIds.R
@@ -1,0 +1,1 @@
+#' @param outcomeCohortIds     A vector of integers corresponding to the outcome cohort IDs   

--- a/man/getIncidenceRates.Rd
+++ b/man/getIncidenceRates.Rd
@@ -11,7 +11,8 @@ getIncidenceRates(
   cgTablePrefix = "cg_",
   databaseTable = "database_meta_data",
   targetIds = NULL,
-  outcomeCohortIds = NULL
+  outcomeIds = NULL,
+  outcomeCohortIds = outcomeIds
 )
 }
 \arguments{
@@ -26,6 +27,8 @@ getIncidenceRates(
 \item{databaseTable}{The name of the table with the database details (default 'database_meta_data')}
 
 \item{targetIds}{A vector of integers corresponding to the target cohort IDs}
+
+\item{outcomeIds}{A vector of integers corresponding to the outcome cohort IDs}
 
 \item{outcomeCohortIds}{A vector of integers corresponding to the outcome cohort IDs}
 }

--- a/man/getIncidenceRates.Rd
+++ b/man/getIncidenceRates.Rd
@@ -11,7 +11,7 @@ getIncidenceRates(
   cgTablePrefix = "cg_",
   databaseTable = "database_meta_data",
   targetIds = NULL,
-  outcomeIds = NULL
+  outcomeCohortIds = NULL
 )
 }
 \arguments{
@@ -27,7 +27,7 @@ getIncidenceRates(
 
 \item{targetIds}{A vector of integers corresponding to the target cohort IDs}
 
-\item{outcomeIds}{A vector of integers corresponding to the outcome cohort IDs}
+\item{outcomeCohortIds}{A vector of integers corresponding to the outcome cohort IDs}
 }
 \value{
 Returns a data.frame with the columns:
@@ -37,6 +37,7 @@ Returns a data.frame with the columns:
  \item{targetId the target cohort unique identifier}
  \item{outcomeName the outcome name}
  \item{outcomeId the outcome unique identifier}
+ \item{outcomeCohortId the outcome cohort Id}
  \item{cleanWindow clean windown around outcome}
  \item{subgroupName name for the result subgroup}
  \item{ageGroupName name for the result age group}


### PR DESCRIPTION
Renaming 'outcomeIds' to 'outcomeCohortIds' to avoid collision with Incidence Rate terminology for 'outcomes'. 
Adding incidence rate outcome_id to the output of getIncidenceRates. 
Adding tar_id to output of getIncidenceRates
Introduced new template for outcomeCohortIds.

### Reason for changes
While historically we referenced outcomes by their cohort IDs, in Incidence rate the Outcome is defined in 2 parts: the cohort that identifies the people, and a clean window which determines a cooldown period between new events.

The CohortIncidence outcome definition can be found [here](https://ohdsi.github.io/CohortIncidence/reference/Outcome.html).  The outcome_id identifies the cohort_id + clean window parameter.  Calling the outcome cohort ID 'outcome id' introduces confusion.

Acknowledging that the OhdsiReportGenerator likes to work in terms of Targets, Outcomes, etc. and fetch results based on those ideas, the API was left in tact to search for results based on a cohort ID, and this remains the case in this PR.

tar_id was added to the output because, like outcome_id, the tar_id uniquely identifies the start/startOffset and end/endOffset.  When filtering to a tar (like on-treatment vs intent to treat) you should use tar_ids that identify those (ie: tar_id = 1), not filter on the paramters(ie: start=start, start_offset = 0, end=end, end_offset = 0).

The outcomeCohortIds template was added to correspond to the style in the repository.


